### PR TITLE
issue 133: ^c breaking infinite loop in scan

### DIFF
--- a/kx.c
+++ b/kx.c
@@ -141,9 +141,10 @@ Z K scan2l(K a, V *p, K b)
       cd(v);cd(w);cd(d);
       d=c;
     }
-    if(flag){cd(c);cd(d);break;}
+    if(flag||interrupted){cd(c);cd(d);break;}
     c=dv_ex(0,p-1,d);cd(d);
   }
+  if (interrupted){interrupted=0;/*cd(u);*/ R BE; }
   R u;
 }
 


### PR DESCRIPTION
C-c now breaks infinite loop in scan, may leak memory though. Needs further testing.

I'm not sure if the memory is leaked or just repooled. It seems to be leaked, but if I cd(u), subsequent tries cause a segfault. Could you check it out?

My minimum test case is

```
f:{1,x}
f\1
```

which chews up memory pretty rapidly.
