### PR TITLE
Cleaning up compiler warnings

### DIFF
--- a/src/0.c
+++ b/src/0.c
@@ -917,9 +917,9 @@ K _4d(K x,K y) //see _3d
   P(-1==ksender(sockfd,y,1),DOE)
   K z=0;
 #ifndef WIN32
-  while(!(z=read_tape(sockfd,1)));
+  while(!(z=read_tape(sockfd,1))){}
 #else
-  while(!(z=read_tape(0,sockfd,1)));
+  while(!(z=read_tape(0,sockfd,1))){}
 #endif
   P(!z || z==(K)-1,DOE)
   R z;

--- a/src/k.c
+++ b/src/k.c
@@ -185,7 +185,7 @@ Z int splitprint(V u, const char *s, ...)  //print for either stdout or for 5: m
   else //5: monadic
   { 
     I n=vsnprintf(b,512,s,args);
-    if(!kapn(u,b,n)); //todo: err handling
+    if(!kapn(u,b,n)){} //todo: err handling
   }
   va_end (args);
   R 0;

--- a/src/kc.c
+++ b/src/kc.c
@@ -155,7 +155,7 @@ Z I check() {      //in suspended execution mode: allows checking of state at ti
 
 Z void handle_SIGINT(int sig) { interrupted = 1; }
 
-I lines(FILE*f) {S a=0;I n=0;PDA p=0; while(-1!=line(f,&a,&n,&p));R 0;}
+I lines(FILE*f) {S a=0;I n=0;PDA p=0; while(-1!=line(f,&a,&n,&p)){} R 0;}
     //You could put lines(stdin) in main() to have not-multiplexed command-line-only input
 I line(FILE*f, S*a, I*n, PDA*p) // just starting or just executed: *a=*n=*p=0,  intermediate is non-zero
 {

--- a/src/p.c
+++ b/src/p.c
@@ -407,7 +407,7 @@ I capture(S s,I n,I k,I*m,V*w,I*d,K*locals,K*dict,K func) //IN string, string le
                             }
                           *o=EVP(q);
                         }
-                        else if(7==(*f)->t && 3==(*f)->n) ;// for {} function add args to local dictionary (huh??)
+                        else if(7==(*f)->t && 3==(*f)->n){} // for {} function add args to local dictionary (huh??)
                       }
 
                       kV(g)[CONJ]=z;
@@ -600,7 +600,7 @@ I capture(S s,I n,I k,I*m,V*w,I*d,K*locals,K*dict,K func) //IN string, string le
     CS(MARK_END    ,  z=(V)(DT_OFFSET(end)))
   }
 
-  if(!z) ; //TODO: handle null z, which can happen
+  if(!z){} //TODO: handle null z, which can happen
 
   switch(-M) //Things that need to be stored locally
   {

--- a/src/tests.c
+++ b/src/tests.c
@@ -16,7 +16,7 @@ Z I tests02();
 Z I tests01();
 Z I testsBook();
 
-#define TC_(x, y ) {S s=ts(tp(tc(x, y))); if(test_print) fprintf(stderr, "%s:%u: TC( " x " , " y " ) ... %s\n", __FILE__, __LINE__,s); test_print=0; }
+#define TC_(x, y ) {S s=ts(tp(tc(x, y))); if(test_print) fprintf(stderr, "%s:%u: TC( %s , %s ) ... %s\n", __FILE__, __LINE__, x, y, s); test_print=0; }
 #define TC(x,...) TC_(#x,#__VA_ARGS__)
 
 I passed=0, skipped=0, failed=0;


### PR DESCRIPTION
When compiling Kona using the clang compiler on OSX there were many warnings generated. These fell into two main classes: complaints about control structures with empty bodies and complaints about the use of presumed format string characters in Kona's tests. The following is a good example of the former:

```
src/0.c:920:34: warning: while loop has empty body [-Wempty-body]
  while(!(z=read_tape(sockfd,1)));
```

And the following is an example of the latter:

```
src/tests.c:1134:3: warning: data argument not used by format string [-Wformat-extra-args]
  TC(3 2, y:2 1; 1 2 3 4 y)
  ^~~~~~~~~~~~~~~~~~~~~~~~~
```

Format string warnings were resolved by restructuring the `TC_` macro slightly.

I ran the tests after making my modifications and this should have no impact on behavior. I don't think this strays too far from the existing style of the codebase.
