### PR TITLE
A few more Android changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ OBJS= src/0.o src/c.o src/getline.o src/getline_android.o src/mt.o src/p.o  \
 LDFLAGS = -Wl,--gc-sections -Wl,-z,nocopyreloc -lgcc -no-canonical-prefixes \
           -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -mthumb \
           -lc -lm -ldl
-CFLAGS += -fpic -ffunction-sections -funwind-tables -fstack-protector \
+CFLAGS += -fPIE -fpic -ffunction-sections -funwind-tables -fstack-protector \
           -no-canonical-prefixes -mtune=xscale -msoft-float -mthumb \
           -fomit-frame-pointer -fno-strict-aliasing
 endif

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can find an executable version of Kona [here](https://github.com/kevinlawler
 
 **Build from source**
 
-For OSX, Linux, BSD and Cygwin:
+For OSX, Linux, BSD, Cygwin and Android:
 Navigate to the directory you want to install Kona, then type:
 
     git clone https://github.com/kevinlawler/kona.git
@@ -33,6 +33,10 @@ Navigate to the directory you want to install Kona, then type:
 Then, while in the "kona" directory, run:
 
     ./k                      #./k_test for debug mode
+
+Android builds are similar, but you must set use this command when running `make`:
+
+    make OS=android
 
 For Windows: 
 Pretty much the same process, but you will need MinGW-w64 (Mingw-builds project package), and you will need MSYS (or MSYS2) for bash.  You can start up Kona from MSYS, or from a native Windows "cmd" session.  In MSYS, type "./k" or just type "k" when in the "kona" directory. When in "cmd" just type "k" as "./k" won't work.  You can also double-click on k.exe from Windows Explorer.

--- a/src/getline_android.c
+++ b/src/getline_android.c
@@ -9,27 +9,7 @@
 #include <errno.h>
 #include <stdlib.h>
 
-/* getline */
-
-/*
- * Copyright 2012, The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 I getline(S *s,size_t*n, FILE *f){ R getdelim(s,n,'\n',f);}
-
-/* getdelim */
 
 /* getdelim.c --- Implementation of replacement getdelim function.
    Copyright (C) 1994, 1996-1998, 2001, 2003, 2005-2012 Free Software


### PR DESCRIPTION
- Adds `-fPIE`; this is needed when building for Lollipop. I forgot about that until I updated my phone. :)
- Fixes the licensing of `getline_android.c`. (the code isn't licensed under the BSD *and* GPL!)
- Adds a little piece to the Makefile for building on Android.
