### PR TITLE
Fix issues with reserved parser not reading enough characters

### DIFF
--- a/src/p.c
+++ b/src/p.c
@@ -167,7 +167,7 @@ Z I mark_verb(S s,I n,I i,I*m)
   if(m[i])R 0;
 
   c=0; //case: reserved verb _bin _bd _ssr
-  if('_'==s[i]) while(i+c<n && isalpha(s[i+1+c]))c++;
+  if('_'==s[i]) c=mark_name(s+i+1,n,0,m);
   if(c>1)R 1+c;
 
   if( s[i]=='\\' && (s[i-1]==' ' || s[i+1]==')' )) R 1;


### PR DESCRIPTION
Previously with Kona:

```
ryan@DevPC-LX:~/stuff/kona$ rlwrap k
K Console - Enter \ for help

  _vs0
_vs[0;]
  _vs.a
_vs[.[;];]
  
```

K2:

```
ryan@DevPC-LX:~/stuff/kona$ rlwrap k2
K 2.8 2000-10-10 Copyright (C) 1993-2000 Kx Systems
Evaluation. Not for commercial use. 
\ for help. \\ to exit.

  _vs0
reserved error
_vs0
^
parse error
  _vs.a
reserved error
_vs.a
^
parse error
  
```

Now with Kona:

```
ryan@DevPC-LX:~/stuff/kona$ rlwrap k
K Console - Enter \ for help

  _vs0
reserved error
>  \
  _vs.a
reserved error
>  \
  
```
