### PR TITLE
Fixed signature for EAP (bug #449)

### DIFF
--- a/src/p.c
+++ b/src/p.c
@@ -402,7 +402,7 @@ Z K* inKtreeR(K*p,S t,I create) {
   K e=0;
   if(create) { e=(K)lookupEntryOrCreate(p,k); P(!e,(K*)ME) }
   else { K a=*p; if(5==a->t)e=DE(a,k); P(!e,(K*)0) }
-  if('.'==*t && (!t[1] || '.'==t[1])) { t++; p=(K*)EAP(e); }    //attribute dict
+  if('.'==*t && (!t[1] || '.'==t[1])) { t++; p=EAP(e); }    //attribute dict
   else p=EVP(e); //value
   R inKtreeR(p,t,create);
 }

--- a/src/p.h
+++ b/src/p.h
@@ -19,6 +19,7 @@ K DE(K d,S b);
 K Kd();
 K kerr(cS s);
 K *EVP(K e);
+K *EAP(K e);
 K DI(K d,I i);
 K kap(K *a,V v);
 K ci(K a);


### PR DESCRIPTION
This is a fix for #449 .

There was just no declaration for EAP, so the compiler thought it was getting an int rather than a pointer.

