### PR TITLE
fix build on freebsd

### DIFF
--- a/src/incs.h
+++ b/src/incs.h
@@ -18,6 +18,9 @@
 #include <netdb.h>
 #include <dlfcn.h>
 #include <sys/mman.h>  //mmap
+#ifndef MAP_NORESERVE
+#define MAP_NORESERVE 0
+#endif
 #endif
 
 #include <limits.h>

--- a/src/kc.c
+++ b/src/kc.c
@@ -14,7 +14,7 @@
 #ifndef WIN32
 #include <netinet/tcp.h>
 #include <pthread.h>
-#ifndef PTHREAD_MUTEX_RECURSIVE
+#if !defined(PTHREAD_MUTEX_RECURSIVE) && defined(PTHREAD_MUTEX_RECURSIVE_NP)
 #define PTHREAD_MUTEX_RECURSIVE PTHREAD_MUTEX_RECURSIVE_NP
 #endif
 #else


### PR DESCRIPTION
* `MAP_NORESERVE` is not available
* `PTHREAD_MUTEX_RECURSIVE` is part of an `enum` and can't be checked for with `#ifndef`; `PTHREAD_MUTEX_RECURSIVE_NP` isn't available at all