### PR TITLE
Fix OpenBSD compiler warning.

### DIFF
--- a/src/getline.c
+++ b/src/getline.c
@@ -46,8 +46,7 @@ I getdelim_(S *s,I *n,I d,FILE *f)
   R *n=m;
 }
 
-#if defined(__OpenBSD__) || defined(__NetBSD__) ||  \
-   (defined(__MACH__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070)
+#if defined(__MACH__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070
 I getline(S *s,size_t*n, FILE *f){ R getdelim(s,n,'\n',f);}
 I getdelim(S *s,size_t*n, I d, FILE *f)//target, current capacity, delimiter, file
 {

--- a/src/getline.h
+++ b/src/getline.h
@@ -6,8 +6,7 @@ I getline_(S *s,I *n,FILE *f);
 I appender(S *s,I *n,S t,I k);
 I expander(S *s,I n);
 
-#if defined(__OpenBSD__) || defined(__NetBSD__) || \
-   (defined(__MACH__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070) || \
+#if defined(__MACH__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1070 || \
    defined(__ANDROID__)
 I getline(S *s,size_t * __restrict__ n,FILE *f);
 I getdelim(S *s,size_t * __restrict__ n,I d,FILE *f);

--- a/src/ko.c
+++ b/src/ko.c
@@ -52,7 +52,7 @@ K _kclone(K a)//Deep copy -- eliminate where possible
       )
       CS(2, M(z,kv=newK(-4,3))
             v=(V*)kK(kv);
-            memcpy(v,kW(a),3*sizeof(V));
+            memcpy(v,kW(a),sizeof(V));
         )
       CS(3,M(z,kv=_kclone((K)kV(a)[CODE])))
     }


### PR DESCRIPTION
OpenBSD gcc issues the following warning:
```
cc -O2 -pipe -g -pthread    -c -o src/ko.o src/ko.c                     
src/ko.c: In function '_kclone':    
src/ko.c:53: warning: array size (8) smaller than bound length (24)     
src/ko.c:53: warning: array size (8) smaller than bound length (24)
```
This pull request fixes that warning. If there is a better way to accomplish this, by all means please do the better way.

`k_test` appears happy with this change:
```
/home/brian/kona $ ./k_test                                                          
t:0                                                                                  
t:50                          
t:100                                                                          
t:150                                                                                         
t:200                                                                                                 
t:250                                                                                         
t:300                                                                                                     
t:350                                                                                           
t:400                                                                                         
t:450                                                                                         
t:500                                                                                         
t:550                                                                                           
t:600                                                                                           
t:650                                                                                           
t:700                                                                                           
t:750                                                                                           
t:800                                                                                           
t:850                                                                                           
t:900                                                                                         
t:950                                                                                           
t:1000                                                                                          
t:1050                                                                                          
Test pass rate: 1.0000, Total: 1092, Passed: 1060, Skipped: 32, Failed: 0, Time: 1.720000s 
```
While here, OpenBSD and NetBSD have getline(3) and getdelim(3) and therefore do not need the internal copy. This was noted in issue #448.