### PR TITLE
fix kapi errors + freebsd compile

### DIFF
--- a/src/kapi-test.c
+++ b/src/kapi-test.c
@@ -7,6 +7,10 @@
 Z int pass, fail;
 
 extern K KTREE;
+extern K X(S);
+extern K show(K);
+extern I attend();
+extern void boilerplate();
 
 #define tst(e)	if(e){pass++;}else{fprintf(stderr, "Failed:%s\n", #e); fail++;}
 

--- a/src/kc.c
+++ b/src/kc.c
@@ -14,8 +14,10 @@
 #ifndef WIN32
 #include <netinet/tcp.h>
 #include <pthread.h>
+#ifndef	__FreeBSD__
 #ifndef PTHREAD_MUTEX_RECURSIVE
 #define PTHREAD_MUTEX_RECURSIVE PTHREAD_MUTEX_RECURSIVE_NP
+#endif
 #endif
 #else
 extern void win_usleep(unsigned int); //buggy TDMGCC64 usleep()


### PR DESCRIPTION
This should fix `kapi-test` build + run errors on x86_64 for the existing code. See issue #469.