### PR TITLE
Don't compile with -Ofast on Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ LDFLAGS = -lm
 OBJS= src/0.o src/bswap.o src/c.o src/getline.o src/mt.o src/p.o src/r.o \
       src/k.o src/kc.o src/kx.o src/kg.o src/km.o src/kn.o src/ko.o src/ks.o \
       src/v.o src/va.o src/vc.o src/vd.o src/vf.o src/vg.o src/vq.o
-PRODFLAGS = -Ofast
+PRODFLAGS = -O3
 endif
 
 ifeq (cygwin_nt-6.3,$(OS))


### PR DESCRIPTION
Compiling with `-Ofast` makes Kona produce inconsistent results compared to what it produces with `-O3`. This is reproducible on Darwin and Linux, but the Makefile makes Linux not default to `-Ofast`. This PR fixes the issue.

For an example on how to reproduce this:
- Compile `k` with `-Ofast`.
- run `./k part2.k` in @https://github.com/oskmeister/adventofcode2017/tree/master/2. The result produced by the program will be `238`, whilst it should be `244`.

