### PR TITLE
Fixes compiler warnings around parens in if guards

### DIFF
--- a/src/0.c
+++ b/src/0.c
@@ -91,8 +91,8 @@ K _0m(K a) {
     I k=0; for(j=0;j<=i;j++){if(ss[j]!='\004')ss[k++]=ss[j];}
     z=newK(-3,k-1); for(j=0;j<k-1;++j){kC(z)[j]=ss[j];}
     GC; }
-  else if( (3==ABS(t) && (!strcmp(m,"/dev/fd/0") || !strcmp(m,"/dev/stdin"))) //read stdin
-           || 4==t && (!strcmp(*kS(a),"/dev/fd/0") || !strcmp(*kS(a),"/dev/stdin")) ){
+  else if( (3==ABS(t) && (!strcmp(m,"/dev/fd/0") || !strcmp(m,"/dev/stdin"))) || //read stdin
+	   (4==t && (!strcmp(*kS(a),"/dev/fd/0") || !strcmp(*kS(a),"/dev/stdin"))) ){
     b=getdelim_(&v,&s,EOF,stdin);
     P(freopen_stdin() == NULL, FE)
     if(b==-1){z=newK(0,0); GC;} }

--- a/src/kx.c
+++ b/src/kx.c
@@ -722,7 +722,7 @@ Z K ex0(V*v,K k,I r) //r: {0,1,2} -> {code, (code), [code]}
         if(n)for(i=n-1;i>=-1;i--)if(-1==i||bk(v[i])){         
           if(offsetColon==(v+1+i)[0] && (UI)(v+1+i)[1]>DT_SIZE)fer=1;
           x=ex1(v+1+i,0,&i,n,0); 
-          if(fer1 || fer>0 && (v[0]==(V)offsetColon || v[2]==(V)1) && !fCheck){cd(z); fer1=1; R x;}
+          if(fer1 || ((fer>0 && (v[0]==(V)offsetColon || v[2]==(V)1)) && !fCheck)){cd(z); fer1=1; R x;}
           M(x,z) kK(z)[--e]=bk(x)?2==r?0:_n():x;}  // (c:9;a+b;c:1) oom
   }
 

--- a/src/vf.c
+++ b/src/vf.c
@@ -60,8 +60,8 @@ Z K formatFn(K a){ V *v=kW(a),p; I i,k,n,r=0; K z=0; C t[256]=""; S s=(C*)t;
   SW(a->n){
     CS(1,for(i=0;(p=v[i]);i++){ L q=(L)p;
            if(q<DT_SIZE && q>=DT_SPECIAL_VERB_OFFSET){S u=DT[q].text; n=strlen(u); strncpy(s+r,u,n); r+=n;}
-           else if(k=adverbClass(p)){t[r]=adverbsChar(p); if(k!=1)t[r+1]=':'; r++;}
-           else if(k=sva(p)){t[r]=verbsChar(p); if(k!=2)t[r+1]=':'; r++;}
+           else if((k=adverbClass(p))){t[r]=adverbsChar(p); if(k!=1)t[r+1]=':'; r++;}
+           else if((k=sva(p))){t[r]=verbsChar(p); if(k!=2)t[r+1]=':'; r++;}
            else;}
          n=strlen(s); z=newK(-3,n); memcpy(kC(z),s,n+1);)
     CS(2,)


### PR DESCRIPTION
There were a few warnings being thrown around not having parens around
the '&&' operator in compound logic expressions in if guards and some
warnings about not having parens around the variable assignments in
if guards. This commit fixes the code so that these warnings no longer
occur.

Signed-off-by: zachwick <zach@zachwick.com>