### PR TITLE
Add NetBSD build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,14 @@ OBJS= src/0.o src/bswap.o src/c.o src/getline.o src/mt.o src/p.o src/r.o \
       src/v.o src/va.o src/vc.o src/vd.o src/vf.o src/vg.o src/vq.o
 endif
 
+ifeq (netbsd,$(OS))
+CFLAGS += -pthread
+LDFLAGS = -lm
+OBJS= src/0.o src/bswap.o src/c.o src/getline.o src/mt.o src/p.o src/r.o \
+      src/k.o src/kc.o src/kx.o src/kg.o src/km.o src/kn.o src/ko.o src/ks.o \
+      src/v.o src/va.o src/vc.o src/vd.o src/vf.o src/vg.o src/vq.o
+endif
+
 ifeq (darwin,$(OS))
 LDFLAGS = -lm
 OBJS= src/0.o src/bswap.o src/c.o src/getline.o src/mt.o src/p.o src/r.o \
@@ -163,6 +171,10 @@ src/*.o: src/incs.h src/ts.h Makefile src/k.h
 endif
 
 ifeq (openbsd,$(OS))
+src/*.o: src/incs.h src/ts.h Makefile src/k.h
+endif
+
+ifeq (netbsd,$(OS))
 src/*.o: src/incs.h src/ts.h Makefile src/k.h
 endif
 


### PR DESCRIPTION
Adds support for building from source on NetBSD. Uses the same configuration as the existing FreeBSD and OpenBSD options.

Tested on NetBSD 9.0 with [gmake 4.2.1 from pkgsrc](http://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/devel/gmake/README.html).